### PR TITLE
Fix x86_64 OSI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*.sw*
 *.tar.gz
 *.log
+*.linted
 cache/

--- a/build.sh
+++ b/build.sh
@@ -34,18 +34,22 @@ while [[ $# -gt 0 ]]; do
             help
             exit
             ;;
+        --clear-cache)
+            docker run --rm -v $PWD/cache:/tmp/build -v $PWD:/app pandare/kernel_builder /bin/bash -c "rm -r /tmp/build/*"
+            exit
+            ;;
         --config-only)
             CONFIG_ONLY=true
-            shift # past argument
+            shift # past flag
             ;;
         --versions)
             VERSIONS="$2"
-            shift # past argument
+            shift # past flag
             shift # past value
             ;;
         --targets)
             TARGETS="$2"
-            shift # past argument
+            shift # past flag
             shift # past value
             ;;
         *)

--- a/configs/4.10/x86_64
+++ b/configs/4.10/x86_64
@@ -1,1 +1,3 @@
 #include "x86-common.inc"
+
+CONFIG_SMP=y


### PR DESCRIPTION
Adds two things:
1. sets CONFIG_SMP=y for x86_64 so that `__per_cpu_offsets` exists and thus osi.config generation doesn't fail leaving an empty config
2. Add an option to clear the docker cache volume, as I occasionally hit some issues that resulted in the cache causing the build to fail