### PR TITLE
Updated workflow for Dev 6.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,9 +178,9 @@ jobs:
       - name: Prepare Docker build context for artifact container
         run: |
           # Create a directory for the Docker build context
-          mkdir -p docker-context
+          mkdir -p docker-context/artifacts
           # Copy all intermediate tarballs (xz)
-          find downloaded-kernels -name "build-intermediate-*.tar.gz" -exec cp {} docker-context/ \;
+          find downloaded-kernels -name "build-intermediate-*.tar.gz" -exec cp {} docker-context/artifacts \;
           # Copy the combined kernel tarball
           cp kernels-latest.tar.gz docker-context/
 
@@ -189,13 +189,8 @@ jobs:
         run: |
           cat <<'EOF' > docker-context/Dockerfile
           FROM rehosting/linux_builder:${{ github.ref_name }}
-          COPY build-intermediate-*.tar.gz /tmp/
+          COPY ./artifacts /artifacts
           COPY kernels-latest.tar.gz /linux_builder/kernels-latest.tar.gz
-          RUN mkdir -p /linux_builder/cache && \
-              for archive in /tmp/build-intermediate-*.tar.gz; do \
-                [ -e "\$archive" ] && tar -xzf "\$archive" -C /linux_builder/cache; \
-              done && \
-              rm -f /tmp/build-intermediate-*.tar.gz
           EOF
 
       - name: Log in to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Update Dockerfile
         run: |
           cat <<'EOF' > docker-context/Dockerfile
-          FROM rehosting/linux_builder:latest
+          FROM rehosting/linux_builder:${{ github.ref_name }}
           COPY build-intermediate-*.tar.gz /tmp/
           COPY kernels-latest.tar.gz /linux_builder/kernels-latest.tar.gz
           RUN mkdir -p /linux_builder/cache && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Build this first, build.sh will use it later
       - name: Build kernel_builder Docker image
         run: docker build -t pandare/kernel_builder .
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: rehosting
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create ephemeral Dockerfile
+        run: |
+          cat <<EOF > Dockerfile.linux_builder
+          FROM pandare/kernel_builder
+          COPY . /linux_builder
+          EOF
+
+      - name: Update submodules
+        run: git submodule update --init --depth 1
+
+      - name: Build linux_builder Docker image
+        run: |
+          docker build -t rehosting/linux_builder:${{ github.ref_name }} -t rehosting/linux_builder:latest -f Dockerfile.linux_builder .
+          docker push rehosting/linux_builder:${{ github.ref_name }}
+
+      - name: Push Docker image as latest if on main
+        if: github.ref == 'refs/heads/main'
+        run: docker push rehosting/linux_builder:latest
 
   build:
     needs: prebuild
@@ -33,15 +62,6 @@ jobs:
         version: ["6.13"] # XXX: quotes are necessary, otherwise 4.10 -> 4.1
 
     steps:
-      - uses: actions/checkout@v4 # Clones to $GITHUB_WORKSPACE
-        with:
-          fetch-depth: 0
-          #submodules: 'true'
-
-      # Instead of getting submodules with checkout, we can do it manually to control depth.
-      # We don't want a full Linux history
-      - name: Pull kernel source
-        run: git submodule update --init --depth 1
 
       # - name: Ensure cache directory exists
       #   run: mkdir -p cache
@@ -91,14 +111,14 @@ jobs:
           name: build-output-${{ matrix.target }}.${{ matrix.version }}
           path: kernels-latest.tar.gz
 
-      - name: Tar up intermediate output (xz compression)
-        run: tar -cJvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz linux/${{ matrix.version }}
+      - name: Tar up intermediate output
+        run: tar -czvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.gz cache/${{ matrix.version }}/${{ matrix.target }}
 
-      - name: Upload intermediate output
+      - name: Upload build cache
         uses: actions/upload-artifact@v4
         with:
           name: build-intermediate-${{ matrix.target }}.${{ matrix.version }}
-          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
+          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.gz
 
   aggregate:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -147,26 +167,27 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref_name }}
 
-      - name: Prepare Docker build context for intermediate artifacts
+      - name: Prepare Docker build context for artifact container
         run: |
           # Create a directory for the Docker build context
           mkdir -p docker-context
-          # Clone the linux_builder repo at the current branch or tag
-          git clone --depth 1 --branch "${GITHUB_REF_NAME}" --recurse-submodules https://github.com/${GITHUB_REPOSITORY} docker-context/linux_builder
-          cd docker-context/linux_builder && git submodule update --init --depth 1
           # Copy all intermediate tarballs (xz)
-          find downloaded-kernels -name "build-intermediate-*.tar.xz" -exec cp {} docker-context/ \;
+          find downloaded-kernels -name "build-intermediate-*.tar.gz" -exec cp {} docker-context/ \;
           # Copy the combined kernel tarball
           cp kernels-latest.tar.gz docker-context/
 
       # Note: This assumes that there is no CMD or anything at the end of the Dockerfile
       - name: Update Dockerfile
         run: |
-          cp docker-context/linux_builder/Dockerfile docker-context/
-          cat <<EOF >> docker-context/Dockerfile
-          COPY build-intermediate-*.tar.xz /artifacts/
-          COPY kernels-latest.tar.gz /artifacts/
-          COPY linux_builder /linux_builder
+          cat <<'EOF' > docker-context/Dockerfile
+          FROM rehosting/linux_builder:latest
+          COPY build-intermediate-*.tar.gz /tmp/
+          COPY kernels-latest.tar.gz /linux_builder/kernels-latest.tar.gz
+          RUN mkdir -p /linux_builder/cache && \
+              for archive in /tmp/build-intermediate-*.tar.gz; do \
+                [ -e "\$archive" ] && tar -xzf "\$archive" -C /linux_builder/cache; \
+              done && \
+              rm -f /tmp/build-intermediate-*.tar.gz
           EOF
 
       - name: Log in to Docker Hub
@@ -177,6 +198,6 @@ jobs:
 
       - name: Build and push Docker image
         run: |
-          docker build -t rehosting/linux_builder:${{ github.ref_name }} -t rehosting/linux_builder:latest docker-context
-          docker push rehosting/linux_builder:${{ github.ref_name }}
-          docker push rehosting/linux_builder:latest
+          docker build -t rehosting/linux_builder-artifacts:${{ github.ref_name }} -t rehosting/linux_builder-artifacts:latest docker-context
+          docker push rehosting/linux_builder-artifacts:${{ github.ref_name }}
+          docker push rehosting/linux_builder-artifacts:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+
 jobs:
   build:
     # Only publish on tags. run git tag vX and git push origin vX
@@ -91,7 +93,7 @@ jobs:
           path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
 
   aggregate:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,13 +120,13 @@ jobs:
           path: kernels-latest.tar.gz
 
       - name: Tar up intermediate output
-        run: tar -czvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.gz cache/${{ matrix.version }}/${{ matrix.target }}
+        run: tar -cJvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz cache/${{ matrix.version }}/${{ matrix.target }}
 
       - name: Upload build cache
         uses: actions/upload-artifact@v4
         with:
           name: build-intermediate-${{ matrix.target }}.${{ matrix.version }}
-          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.gz
+          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
 
   aggregate:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -180,7 +180,7 @@ jobs:
           # Create a directory for the Docker build context
           mkdir -p docker-context/artifacts
           # Copy all intermediate tarballs (xz)
-          find downloaded-kernels -name "build-intermediate-*.tar.gz" -exec cp {} docker-context/artifacts \;
+          find downloaded-kernels -name "build-intermediate-*.tar.xz" -exec cp {} docker-context/artifacts \;
           # Copy the combined kernel tarball
           cp kernels-latest.tar.gz docker-context/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  prebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build kernel_builder Docker image
+        run: docker build -t pandare/kernel_builder .
+
   build:
+    needs: prebuild
     # Only publish on tags. run git tag vX and git push origin vX
     # runs-on: self-hosted
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build Kernel for ${{ matrix.target }}
         run: ./build.sh --targets ${{ matrix.target }} --versions ${{ matrix.version }}
-            
+
       # - name: Save kernel build cache
       #   id: save-cache
       #   uses: actions/cache/save@v4
@@ -81,6 +81,15 @@ jobs:
           name: build-output-${{ matrix.target }}.${{ matrix.version }}
           path: kernels-latest.tar.gz
 
+      - name: Tar up intermediate output (xz compression)
+        run: tar -cJvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz linux/${{ matrix.version }}
+
+      - name: Upload intermediate output
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-intermediate-${{ matrix.target }}.${{ matrix.version }}
+          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
+
   aggregate:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
@@ -99,26 +108,24 @@ jobs:
       - name: Combine all kernels into a single archive
         run: |
           rm -rf combined-kernels && mkdir combined-kernels
-          # Extract each kernels-latest.tar.gz archive
-          for archive in $(find downloaded-kernels -name "*.tar.gz"); do
+          # Only extract kernels-latest.tar.gz archives, not intermediate ones
+          for archive in $(find downloaded-kernels -name "kernels-latest.tar.gz"); do
             tar -xzf "$archive" -C combined-kernels
           done
 
           # Combine OSI profiles for each kernel version
-          # otherwise the extracted kernel configs willc lobber each other
+          # otherwise the extracted kernel configs will clobber each other
           if [ -d combined-kernels/kernels/4.10 ] ; then
-            for archive in $(find downloaded-kernels -name "*.tar.gz"); do
+            for archive in $(find downloaded-kernels -name "kernels-latest.tar.gz"); do
               tar -O -xf "$archive" "kernels/4.10/osi.config";
             done > combined-kernels/kernels/4.10/osi.config
           fi
 
           if [ -d combined-kernels/kernels/6.13 ] ; then
-            for archive in $(find downloaded-kernels -name "*.tar.gz"); do
+            for archive in $(find downloaded-kernels -name "kernels-latest.tar.gz"); do
               tar -O -xf "$archive" "kernels/6.13/osi.config";
             done > combined-kernels/kernels/6.13/osi.config
           fi
-
-
 
           # Create a new single archive from the combined content
           tar -czvf kernels-latest.tar.gz -C combined-kernels .
@@ -129,3 +136,37 @@ jobs:
           files: kernels-latest.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
+
+      - name: Prepare Docker build context for intermediate artifacts
+        run: |
+          # Create a directory for the Docker build context
+          mkdir -p docker-context
+          # Clone the linux_builder repo at the current branch or tag
+          git clone --depth 1 --branch "${GITHUB_REF_NAME}" --recurse-submodules https://github.com/${GITHUB_REPOSITORY} docker-context/linux_builder
+          cd docker-context/linux_builder && git submodule update --init --depth 1
+          # Copy all intermediate tarballs (xz)
+          find downloaded-kernels -name "build-intermediate-*.tar.xz" -exec cp {} docker-context/ \;
+          # Copy the combined kernel tarball
+          cp kernels-latest.tar.gz docker-context/
+
+      # Note: This assumes that there is no CMD or anything at the end of the Dockerfile
+      - name: Update Dockerfile
+        run: |
+          cp docker-context/linux_builder/Dockerfile docker-context/
+          cat <<EOF >> docker-context/Dockerfile
+          COPY build-intermediate-*.tar.xz /artifacts/
+          COPY kernels-latest.tar.gz /artifacts/
+          COPY linux_builder /linux_builder
+          EOF
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: rehosting
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t rehosting/linux_builder:${{ github.ref_name }} -t rehosting/linux_builder:latest docker-context
+          docker push rehosting/linux_builder:${{ github.ref_name }}
+          docker push rehosting/linux_builder:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           files: kernels-latest.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ github.ref_name }}
 
       - name: Prepare Docker build context for intermediate artifacts
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,10 @@ jobs:
       - name: Build Kernel for ${{ matrix.target }}
         run: |
             mkdir -p cache
-            docker run  --rm -v $PWD/cache:/tmp/build \
+            docker run --rm -v $PWD/cache:/tmp/build \
               rehosting/linux_builder:${{ github.ref_name }} \
-              bash ./_in_container_build.sh false ${{ matrix.version }} ${{ matrix.target}} false false false
+              bash -c "./_in_container_build.sh false ${{ matrix.version }} ${{ matrix.target}} false false false && cp kernels-latest.tar.gz /tmp/build/kernels-latest.tar.gz"
+            mv cache/kernels-latest.tar.gz kernels-latest.tar.gz
 
       # - name: Save kernel build cache
       #   id: save-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
         version: ["6.13"] # XXX: quotes are necessary, otherwise 4.10 -> 4.1
 
     steps:
+      - name: Pull prebuilt image
+        run: docker pull rehosting/linux_builder:${{ github.ref_name }}
 
       # - name: Ensure cache directory exists
       #   run: mkdir -p cache
@@ -82,7 +84,11 @@ jobs:
         # run: ./build.sh --targets ${{ matrix.target }} --versions ${{ matrix.version }} --config-only
 
       - name: Build Kernel for ${{ matrix.target }}
-        run: ./build.sh --targets ${{ matrix.target }} --versions ${{ matrix.version }}
+        run: |
+            mkdir -p cache
+            docker run  --rm -v $PWD/cache:/tmp/build \
+              rehosting/linux_builder:${{ github.ref_name }} \
+              bash /linux_builder/_in_container_build.sh false ${{ matrix.version }} ${{ matrix.target}} false false false
 
       # - name: Save kernel build cache
       #   id: save-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,14 +119,15 @@ jobs:
           name: build-output-${{ matrix.target }}.${{ matrix.version }}
           path: kernels-latest.tar.gz
 
-      - name: Tar up intermediate output
-        run: tar -cvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz --use-compress-program="xz -9" cache/${{ matrix.version }}/${{ matrix.target }}
+      #This took too much space, even with xz -9
+      #- name: Tar up intermediate output
+      #  run: tar -cvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz --use-compress-program="xz -9" cache/${{ matrix.version }}/${{ matrix.target }}
 
-      - name: Upload build cache
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-intermediate-${{ matrix.target }}.${{ matrix.version }}
-          path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
+      #- name: Upload build cache
+      #  uses: actions/upload-artifact@v4
+      #  with:
+      #    name: build-intermediate-${{ matrix.target }}.${{ matrix.version }}
+      #    path: build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz
 
   aggregate:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
@@ -179,8 +180,8 @@ jobs:
         run: |
           # Create a directory for the Docker build context
           mkdir -p docker-context/artifacts
-          # Copy all intermediate tarballs (xz)
-          find downloaded-kernels -name "build-intermediate-*.tar.xz" -exec cp {} docker-context/artifacts \;
+          # Not copying intermediate tarballs (xz)
+          # find downloaded-kernels -name "build-intermediate-*.tar.xz" -exec cp {} docker-context/artifacts \;
           # Copy the combined kernel tarball
           cp kernels-latest.tar.gz docker-context/
 
@@ -189,7 +190,8 @@ jobs:
         run: |
           cat <<'EOF' > docker-context/Dockerfile
           FROM rehosting/linux_builder:${{ github.ref_name }}
-          COPY ./artifacts /artifacts
+          # Not doing this anymore
+          # COPY ./artifacts /artifacts
           COPY kernels-latest.tar.gz /linux_builder/kernels-latest.tar.gz
           EOF
 
@@ -199,8 +201,9 @@ jobs:
           username: rehosting
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        run: |
-          docker build -t rehosting/linux_builder-artifacts:${{ github.ref_name }} -t rehosting/linux_builder-artifacts:latest docker-context
-          docker push rehosting/linux_builder-artifacts:${{ github.ref_name }}
-          docker push rehosting/linux_builder-artifacts:latest
+      # Not building artifacts image anymore
+      #- name: Build and push Docker image
+      #  run: |
+      #    docker build -t rehosting/linux_builder-artifacts:${{ github.ref_name }} -t rehosting/linux_builder-artifacts:latest docker-context
+      #    docker push rehosting/linux_builder-artifacts:${{ github.ref_name }}
+      #    docker push rehosting/linux_builder-artifacts:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
           cat <<EOF > Dockerfile.linux_builder
           FROM pandare/kernel_builder
           COPY . /linux_builder
+          RUN ln -s /linux_builder /app
+          WORKDIR /app
           EOF
 
       - name: Update submodules
@@ -88,7 +90,7 @@ jobs:
             mkdir -p cache
             docker run  --rm -v $PWD/cache:/tmp/build \
               rehosting/linux_builder:${{ github.ref_name }} \
-              bash /linux_builder/_in_container_build.sh false ${{ matrix.version }} ${{ matrix.target}} false false false
+              bash ./_in_container_build.sh false ${{ matrix.version }} ${{ matrix.target}} false false false
 
       # - name: Save kernel build cache
       #   id: save-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           path: kernels-latest.tar.gz
 
       - name: Tar up intermediate output
-        run: tar -cJvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz cache/${{ matrix.version }}/${{ matrix.target }}
+        run: tar -cvf build-intermediate-${{ matrix.target }}.${{ matrix.version }}.tar.xz --use-compress-program="xz -9" cache/${{ matrix.version }}/${{ matrix.target }}
 
       - name: Upload build cache
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Publishes a linux_builder container. We now do the submodule init and source code checkout in that container before running the matrix. Attempted to, but could not get an artifact container built. 