### PR TITLE
configs/6.13: enable CONFIG_MAC80211_HWSIM

### DIFF
--- a/configs/6.13/all-common.inc
+++ b/configs/6.13/all-common.inc
@@ -143,6 +143,10 @@ CONFIG_KSM=y
 CONFIG_LEGACY_PTY_COUNT=16
 CONFIG_LOG_BUF_SHIFT=14
 CONFIG_MAC80211=y
+// Virtual 802.11 radio for rehosting devices whose real Wi-Fi driver (mt76 etc.) cannot
+// load on the donor kernel: a real cfg80211 phy with full nl80211 so wifi-detect/hostapd/
+// netifd bring up wlan* with no RF hardware. Built-in so the phy exists at boot. RUT2M RF model.
+CONFIG_MAC80211_HWSIM=y
 CONFIG_MAGIC_SYSRQ=y
 CONFIG_MINIX_FS=y
 CONFIG_MODULES=y


### PR DESCRIPTION
## What

Enables `CONFIG_MAC80211_HWSIM` in the shared 6.13 config (`configs/6.13/all-common.inc`).

## Why

`cfg80211`/`mac80211` are already `=y`, but under emulation no real radio driver can load (vendor Wi-Fi modules are built for a different kernel), so there is no phy and `wifi` detection finds nothing. Building in the virtual radio gives a real phy with full nl80211, so `wifi-detect`/`hostapd`/`netifd` can bring up `wlan*` with no RF hardware. This is useful for validating a rehosted target's Wi-Fi bring-up chain end to end.

## Notes

- One line added next to `CONFIG_MAC80211`. `--config-only` lints cleanly for mipsel (deps satisfied); the option lands in the resulting linted defconfig.
- `.inc` files are run through the C preprocessor, so the explanatory comment uses `//` (a `#` line is parsed as a preprocessor directive and errors).